### PR TITLE
Add installation and run script

### DIFF
--- a/.mumuki-offline/install.sh
+++ b/.mumuki-offline/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+git submodule update --init --recursive

--- a/.mumuki-offline/run.sh
+++ b/.mumuki-offline/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bundle exec rackup -p$1


### PR DESCRIPTION
I think every runner should expose a common way to *install* and *run* inside the VM.
With this files, it will be possible to install any runner with [./install-runner.rb --install gobstones](https://github.com/mumuki/mumuki-offline/pull/2/files)